### PR TITLE
improve(extract): consolidate scripts, add retries, logging, schema validation

### DIFF
--- a/airflow/dags/etl_dag.py
+++ b/airflow/dags/etl_dag.py
@@ -81,12 +81,12 @@ def skip_if_disabled(flag_name: str):
 # TASK CALLABLE
 ##################################################
 
-def run_extract(script_name: str):
+def run_extract(raw_file: str):
     # One global switch for ALL extract tasks
     skip_if_disabled(GLOBAL_EXTRACT_FLAG)
 
-    module = __import__(script_name)
-    module.main()
+    import extract_to_s3
+    extract_to_s3.extract(raw_file)
 
 ##################################################
 # DBT OPERATOR HELPER
@@ -134,24 +134,25 @@ with DAG(
     # Step 1: Extract all IMDB raw files to S3/MinIO #
     ##################################################
     EXTRACT_SCRIPT_DIR = "/opt/airflow/extract/src/"
-    extract_raw_scripts = [
-        "extract_name_basics_to_s3",
-        "extract_title_principals_to_s3",
-        "extract_title_akas_to_s3",
-        "extract_title_basics_to_s3",
-        "extract_title_crew_to_s3",
-        "extract_title_episode_to_s3",
-        "extract_title_ratings_to_s3"
-        ]
+    extract_raw_files = [
+        "name.basics.tsv.gz",
+        "title.principals.tsv.gz",
+        "title.akas.tsv.gz",
+        "title.basics.tsv.gz",
+        "title.crew.tsv.gz",
+        "title.episode.tsv.gz",
+        "title.ratings.tsv.gz",
+    ]
 
     extract_tasks = []
     sys.path.append(EXTRACT_SCRIPT_DIR)
 
-    for script in extract_raw_scripts:
+    for raw_file in extract_raw_files:
+        task_id = "extract_" + raw_file.replace(".", "_").replace("_tsv_gz", "_to_s3")
         extract_task = PythonOperator(
-            task_id=f"{script}",
+            task_id=task_id,
             python_callable=run_extract,
-            op_kwargs={"script_name": script},
+            op_kwargs={"raw_file": raw_file},
             execution_timeout=timedelta(minutes=30),
         )
         extract_tasks.append(extract_task)

--- a/extract/src/extract_name_basics_to_s3.py
+++ b/extract/src/extract_name_basics_to_s3.py
@@ -1,7 +1,0 @@
-from extract_to_s3 import extract
-
-def main():
-    extract("name.basics.tsv.gz")
-
-if __name__ == "__main__":
-    main()

--- a/extract/src/extract_title_akas_to_s3.py
+++ b/extract/src/extract_title_akas_to_s3.py
@@ -1,7 +1,0 @@
-from extract_to_s3 import extract
-
-def main():
-    extract("title.akas.tsv.gz")
-
-if __name__ == "__main__":
-    main()

--- a/extract/src/extract_title_basics_to_s3.py
+++ b/extract/src/extract_title_basics_to_s3.py
@@ -1,7 +1,0 @@
-from extract_to_s3 import extract
-
-def main():
-    extract("title.basics.tsv.gz")
-
-if __name__ == "__main__":
-    main()

--- a/extract/src/extract_title_crew_to_s3.py
+++ b/extract/src/extract_title_crew_to_s3.py
@@ -1,7 +1,0 @@
-from extract_to_s3 import extract
-
-def main():
-    extract("title.crew.tsv.gz")
-
-if __name__ == "__main__":
-    main()

--- a/extract/src/extract_title_episode_to_s3.py
+++ b/extract/src/extract_title_episode_to_s3.py
@@ -1,7 +1,0 @@
-from extract_to_s3 import extract
-
-def main():
-    extract("title.episode.tsv.gz")
-
-if __name__ == "__main__":
-    main()

--- a/extract/src/extract_title_principals_to_s3.py
+++ b/extract/src/extract_title_principals_to_s3.py
@@ -1,7 +1,0 @@
-from extract_to_s3 import extract
-
-def main():
-    extract("title.principals.tsv.gz")
-
-if __name__ == "__main__":
-    main()

--- a/extract/src/extract_title_ratings_to_s3.py
+++ b/extract/src/extract_title_ratings_to_s3.py
@@ -1,7 +1,0 @@
-from extract_to_s3 import extract
-
-def main():
-    extract("title.ratings.tsv.gz")
-
-if __name__ == "__main__":
-    main()

--- a/extract/src/extract_to_s3.py
+++ b/extract/src/extract_to_s3.py
@@ -1,8 +1,16 @@
 import boto3
 from botocore.client import Config
-from datetime import datetime
+from datetime import datetime, timezone
+import gzip
+import io
+import logging
 import os
+import sys
+import time
 import requests
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 S3_ENDPOINT = os.environ['S3_ENDPOINT']
 AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
@@ -11,40 +19,121 @@ REGION = os.environ['REGION']
 SOURCE_URL_PREFIX = "https://datasets.imdbws.com/"
 ROOT_BUCKET = "data"
 
-def download_raw_data_from_source(url):
-    """
-    Return a file-like object streaming from the URL
-    """
-    response = requests.get(url, stream=True)
-    response.raise_for_status()
-    return response.raw  # raw is a file-like object
+# Expected tab-separated headers per IMDB file
+EXPECTED_HEADERS = {
+    "name.basics.tsv.gz": [
+        "nconst", "primaryName", "birthYear", "deathYear",
+        "primaryProfession", "knownForTitles",
+    ],
+    "title.akas.tsv.gz": [
+        "titleId", "ordering", "title", "region", "language",
+        "types", "attributes", "isOriginalTitle",
+    ],
+    "title.basics.tsv.gz": [
+        "tconst", "titleType", "primaryTitle", "originalTitle",
+        "isAdult", "startYear", "endYear", "runtimeMinutes", "genres",
+    ],
+    "title.crew.tsv.gz": ["tconst", "directors", "writers"],
+    "title.episode.tsv.gz": [
+        "tconst", "parentTconst", "seasonNumber", "episodeNumber",
+    ],
+    "title.principals.tsv.gz": [
+        "tconst", "ordering", "nconst", "category", "job", "characters",
+    ],
+    "title.ratings.tsv.gz": ["tconst", "averageRating", "numVotes"],
+}
+
+MAX_RETRIES = 3
+REQUEST_TIMEOUT = 30
 
 
-def upload_raw_data_to_s3(s3_client, file_obj, bucket: str, raw_file: str):
+def download_raw_data_from_source(url: str) -> requests.Response:
+    """
+    Return a streaming Response from the URL, with retry/backoff.
+    Raises on non-2xx or after exhausting retries.
+    """
+    last_exc = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            logger.info("Downloading %s (attempt %d/%d)", url, attempt + 1, MAX_RETRIES)
+            response = requests.get(url, stream=True, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+            logger.debug("Download started; headers=%s", dict(response.headers))
+            return response
+        except Exception as e:
+            last_exc = e
+            if attempt < MAX_RETRIES - 1:
+                delay = 2 ** attempt
+                logger.warning(
+                    "Request failed (attempt %d/%d): %s — retrying in %ds",
+                    attempt + 1, MAX_RETRIES, e, delay,
+                )
+                time.sleep(delay)
+            else:
+                logger.error("All %d download attempts failed for %s: %s", MAX_RETRIES, url, e)
+    raise last_exc
+
+
+def validate_schema(raw_file: str, file_obj) -> None:
+    """
+    Read the first line of the gzip stream and verify it matches expected headers.
+    Raises ValueError with a descriptive message on mismatch.
+    file_obj must support .read() and will be partially consumed; callers should
+    pass a fresh stream and re-open for the actual upload.
+    """
+    expected = EXPECTED_HEADERS.get(raw_file)
+    if expected is None:
+        logger.warning("No expected headers registered for %s — skipping schema validation", raw_file)
+        return
+
+    chunk = file_obj.read(4096)
+    with gzip.open(io.BytesIO(chunk), "rb") as gz:
+        first_line = gz.readline().decode("utf-8").rstrip("\n")
+
+    actual_cols = first_line.split("\t")
+    if actual_cols != expected:
+        raise ValueError(
+            f"Schema mismatch for {raw_file}.\n"
+            f"  Expected : {expected}\n"
+            f"  Got      : {actual_cols}"
+        )
+    logger.info("Schema validation passed for %s", raw_file)
+
+
+def upload_raw_data_to_s3(s3_client, file_obj, bucket: str, raw_file: str) -> str:
     """
     Upload a file-like object to S3/MinIO with date partitioning.
-
-    Parameters:
-    - s3_client: boto3 S3 client
-    - file_obj: file-like object (streaming)
-    - bucket: target bucket name
-    - raw_file: name of the file (e.g., 'title.basics.tsv.gz')
+    Returns the object key that was uploaded.
     """
-    # Get current UTC date
-    today = datetime.utcnow()
+    today = datetime.now(timezone.utc)
     year = today.year
     month = f"{today.month:02d}"
     day = f"{today.day:02d}"
 
-    # Build S3 object key with partition
     object_key = f"imdb/year={year}/month={month}/day={day}/{raw_file}"
 
-    # Upload the file-like object to S3/MinIO
+    logger.info("Uploading %s → %s/%s", raw_file, bucket, object_key)
     s3_client.upload_fileobj(file_obj, bucket, object_key)
+    logger.info("Upload complete: %s/%s", bucket, object_key)
 
-    print(f"Uploaded {raw_file} → {bucket}/{object_key}")
+    # Verify upload
+    head = s3_client.head_object(Bucket=bucket, Key=object_key)
+    content_length = head.get("ContentLength", 0)
+    if content_length <= 0:
+        raise RuntimeError(
+            f"S3 upload verification failed for {object_key}: ContentLength={content_length}"
+        )
+    logger.debug("S3 verification OK — ContentLength=%d bytes", content_length)
 
-def extract(raw_file):
+    return object_key
+
+
+def extract(raw_file: str) -> None:
+    """
+    Download raw_file from IMDB datasets, validate schema, and upload to S3.
+    """
+    logger.info("Starting extract for %s", raw_file)
+
     s3 = boto3.client(
         "s3",
         endpoint_url=S3_ENDPOINT,
@@ -57,13 +146,38 @@ def extract(raw_file):
     # Ensure bucket exists
     try:
         s3.head_bucket(Bucket=ROOT_BUCKET)
-        print(f"Bucket {ROOT_BUCKET} already exists")
-    except:
+        logger.info("Bucket %s already exists", ROOT_BUCKET)
+    except Exception as e:
+        logger.info("Bucket %s not found (%s) — creating it", ROOT_BUCKET, e)
         s3.create_bucket(Bucket=ROOT_BUCKET)
-        print(f"Created bucket {ROOT_BUCKET}")
-
+        logger.info("Created bucket %s", ROOT_BUCKET)
 
     url = f"{SOURCE_URL_PREFIX}{raw_file}"
-    print(f"Streaming {raw_file} from {url}")
-    file_obj = download_raw_data_from_source(url)
-    upload_raw_data_to_s3(s3, file_obj, ROOT_BUCKET, raw_file)
+
+    # --- Schema validation pass (download a fresh stream just for header check) ---
+    expected = EXPECTED_HEADERS.get(raw_file)
+    if expected is not None:
+        logger.info("Validating schema for %s", raw_file)
+        validation_response = download_raw_data_from_source(url)
+        validate_schema(raw_file, validation_response.raw)
+
+    # --- Actual upload pass ---
+    logger.info("Streaming %s from %s", raw_file, url)
+    upload_response = download_raw_data_from_source(url)
+    upload_raw_data_to_s3(s3, upload_response.raw, ROOT_BUCKET, raw_file)
+
+    logger.info("Extract finished for %s", raw_file)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <filename>  (e.g. name.basics.tsv.gz)", file=sys.stderr)
+        print(f"Available files: {', '.join(sorted(EXPECTED_HEADERS))}", file=sys.stderr)
+        sys.exit(1)
+
+    raw_file = sys.argv[1]
+    extract(raw_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Consolidated 7 near-identical wrapper scripts into a single parametrized `extract_to_s3.py`
- Added `timeout=30` + exponential backoff retry loop (3 retries, 2^n seconds) to HTTP requests
- Replaced deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`
- Fixed bare `except:` → `except Exception as e:` with logging
- Added schema validation: reads first gzip line and validates headers per file
- Replaced all `print()` with `logging` (INFO/DEBUG/ERROR)
- Added S3 upload verification via `head_object()` after upload

## Test plan
- [ ] Trigger extract DAG tasks and verify structured logs appear
- [ ] Verify schema validation raises on header mismatch
- [ ] Verify S3 upload verification passes for a successful upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)