### PR TITLE
improve(transform): fix tests, add partitioning, freshness, LLM-friendly docs

### DIFF
--- a/transform/data_platform/dbt_project.yml
+++ b/transform/data_platform/dbt_project.yml
@@ -35,7 +35,9 @@ models:
         +catalog: demo
         +file_format: iceberg
         +materialized: table
+        +partition_by: "snapshot_date"
       analytics:
         +catalog: demo
         +file_format: iceberg
-        +materialized: table        
+        +materialized: table
+        +partition_by: "snapshot_date"

--- a/transform/data_platform/models/stage/analytics/dimensions/dim_person.sql
+++ b/transform/data_platform/models/stage/analytics/dimensions/dim_person.sql
@@ -1,6 +1,7 @@
 SELECT
 	person_id,
-	name, 
-	birth_year, 
-	death_year
+	name,
+	birth_year,
+	death_year,
+	death_year IS NULL AS is_alive
 FROM {{ source('stage_canonical', 'person') }}

--- a/transform/data_platform/models/stage/analytics/dimensions/dim_person.yml
+++ b/transform/data_platform/models/stage/analytics/dimensions/dim_person.yml
@@ -31,3 +31,9 @@ models:
       - name: death_year
         description: Year the person died if applicable.
         data_type: integer
+
+      - name: is_alive
+        description: Indicates whether the person is alive (true when death_year is null).
+        data_type: boolean
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/analytics/dimensions/dim_title.yml
+++ b/transform/data_platform/models/stage/analytics/dimensions/dim_title.yml
@@ -55,9 +55,13 @@ models:
         data_type: integer
 
       - name: decade
-        description: Decade derived from the release year (e.g. 1990s, 2000s).
+        description: >
+          Decade derived from the release year (e.g. 1990s, 2000s).
+          Values: 1890s, 1900s, 1910s, 1920s, 1930s, 1940s, 1950s, 1960s, 1970s, 1980s, 1990s, 2000s, 2010s, 2020s.
         data_type: string
 
       - name: rating_bucket
-        description: Rating bucket derived from the average rating.
+        description: >
+          Rating bucket derived from the average rating.
+          Values: no_rating, 0-5, 5-7, 7-8, 8-9, 9+.
         data_type: string

--- a/transform/data_platform/models/stage/analytics/facts/fact_episode.yml
+++ b/transform/data_platform/models/stage/analytics/facts/fact_episode.yml
@@ -21,7 +21,7 @@ models:
           - relationships:
               to: ref('dim_title')
               field: title_id
-              severity: warn
+              severity: error
 
       - name: episode_title_id
         description: Foreign key to the episode title in dim_title.
@@ -31,7 +31,7 @@ models:
           - relationships:
               to: ref('dim_title')
               field: title_id
-              severity: warn
+              severity: error
 
       - name: season_number
         description: Season number within the series.

--- a/transform/data_platform/models/stage/analytics/facts/fact_title_release.yml
+++ b/transform/data_platform/models/stage/analytics/facts/fact_title_release.yml
@@ -18,7 +18,7 @@ models:
           - relationships:
               to: ref('dim_title')
               field: title_id
-              severity: warn
+              severity: error
 
       - name: localized_title
         description: Localized title used in a specific region.

--- a/transform/data_platform/models/stage/canonical/genre.yml
+++ b/transform/data_platform/models/stage/canonical/genre.yml
@@ -14,16 +14,25 @@ models:
           - not_null
           - unique
       - name: genre_name
-        data_type: string      
+        data_type: string
         description: Name of the genre (e.g. Drama, Comedy, Action).
         tests:
           - not_null
           - unique
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
-        data_type: int          
+        data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/person.yml
+++ b/transform/data_platform/models/stage/canonical/person.yml
@@ -2,7 +2,7 @@ models:
   - name: person
     config:
       contract:
-        enforced: true  
+        enforced: true
     description: >
       Master table containing people involved in titles,
       such as actors, directors, writers, and other crew members.
@@ -26,17 +26,18 @@ models:
         description: Year the person died, if applicable.
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
         data_type: int
-      - name: ingested_at_timestamp
-        data_type: timestamp
-
-      - name: snapshot_date
-        data_type: date
-
-      - name: snapshot_try
-        data_type: int        
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/role.yml
+++ b/transform/data_platform/models/stage/canonical/role.yml
@@ -2,7 +2,7 @@ models:
   - name: role
     config:
       contract:
-        enforced: true  
+        enforced: true
     description: >
       Lookup table defining high-level roles a person can have
       in relation to a title (e.g. Actor, Director).
@@ -21,9 +21,18 @@ models:
           - unique
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
-        data_type: int          
+        data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/role_person.yml
+++ b/transform/data_platform/models/stage/canonical/role_person.yml
@@ -2,7 +2,7 @@ models:
   - name: role_person
     config:
       contract:
-        enforced: true    
+        enforced: true
     description: >
       Bridge table mapping people to roles they can perform,
       independent of a specific title.
@@ -30,9 +30,18 @@ models:
               field: person_id
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
-        data_type: int        
+        data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/title.yml
+++ b/transform/data_platform/models/stage/canonical/title.yml
@@ -2,7 +2,7 @@ models:
   - name: title
     config:
       contract:
-        enforced: true    
+        enforced: true
     description: >
       Core table representing IMDb titles such as movies,
       TV series, and episodes.
@@ -36,6 +36,8 @@ models:
         description: Indicates whether the title is intended for adults.
         tests:
           - not_null
+          - accepted_values:
+              values: ['true', 'false']
       - name: release_year
         data_type: int
         description: Year the title was first released.
@@ -54,9 +56,18 @@ models:
           - not_null
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
-        data_type: int          
+        data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/title_context.yml
+++ b/transform/data_platform/models/stage/canonical/title_context.yml
@@ -2,7 +2,7 @@ models:
   - name: title_context
     config:
       contract:
-        enforced: true    
+        enforced: true
     description: >
       Lookup table describing attributes associated with localized titles,
       such as alternative titles, original titles, or other naming qualifiers.
@@ -37,12 +37,21 @@ models:
           - unofficial: incorrect, bootleg, or rumored titles
           - other: fallback classification when no rule applies
         tests:
-          - not_null          
+          - not_null
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
-        data_type: int          
+        data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/title_episode.yml
+++ b/transform/data_platform/models/stage/canonical/title_episode.yml
@@ -2,7 +2,7 @@ models:
   - name: title_episode
     config:
       contract:
-        enforced: true      
+        enforced: true
     description: >
       Table representing episodic relationships between titles,
       linking episodes to their parent TV series.
@@ -15,7 +15,7 @@ models:
           - relationships:
               to: ref('title')
               field: title_id
-              severity: warn
+              severity: error
       - name: series_title_id
         data_type: string
         description: Foreign key to the TV series title.
@@ -24,7 +24,7 @@ models:
           - relationships:
               to: ref('title')
               field: title_id
-              severity: warn
+              severity: error
       - name: season_number
         data_type: int
         description: Season number of the episode.
@@ -33,9 +33,18 @@ models:
         description: Episode number within the season.
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
-        data_type: int        
+        data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/title_genre.yml
+++ b/transform/data_platform/models/stage/canonical/title_genre.yml
@@ -21,7 +21,7 @@ models:
               to: ref('genre')
               field: genre_id
       - name: title_id
-        data_type: string      
+        data_type: string
         description: Foreign key to the title associated with the genre.
         tests:
           - not_null
@@ -30,9 +30,18 @@ models:
               field: title_id
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
         data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/title_localized.yml
+++ b/transform/data_platform/models/stage/canonical/title_localized.yml
@@ -2,7 +2,7 @@ models:
   - name: title_localized
     config:
       contract:
-        enforced: true        
+        enforced: true
     description: >
       Table containing localized versions of titles by region and language,
       including alternative and original titles.
@@ -25,7 +25,7 @@ models:
           - relationships:
               to: ref('title')
               field: title_id
-              severity: warn
+              severity: error
       - name: title
         data_type: string
         description: Localized title text.
@@ -64,9 +64,18 @@ models:
           - not_null
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
-        data_type: int          
+        data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/title_person_role.yml
+++ b/transform/data_platform/models/stage/canonical/title_person_role.yml
@@ -2,7 +2,7 @@ models:
   - name: title_person_role
     config:
       contract:
-        enforced: true  
+        enforced: true
     description: >
       Fact table linking titles, people, and roles,
       describing who did what on each title.
@@ -52,9 +52,18 @@ models:
           - not_null
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
-        data_type: int          
+        data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/canonical/title_type.yml
+++ b/transform/data_platform/models/stage/canonical/title_type.yml
@@ -2,7 +2,7 @@ models:
   - name: title_type
     config:
       contract:
-        enforced: true    
+        enforced: true
     description: >
       Lookup table defining the type of a title,
       such as movie, TV series, episode, or short.
@@ -19,11 +19,22 @@ models:
         tests:
           - not_null
           - unique
+          - accepted_values:
+              values: [movie, tvSeries, short, tvEpisode, tvMiniSeries, tvMovie, tvShort, tvSpecial, video, videoGame]
       - name: ingested_at_timestamp
         data_type: timestamp
+        description: Timestamp when the record was ingested into the data platform.
+        tests:
+          - not_null
 
       - name: snapshot_date
         data_type: date
+        description: Date of the snapshot from which this record was loaded.
+        tests:
+          - not_null
 
       - name: snapshot_try
-        data_type: int          
+        data_type: int
+        description: Retry attempt number for the snapshot ingestion.
+        tests:
+          - not_null

--- a/transform/data_platform/models/stage/raw/sources.yml
+++ b/transform/data_platform/models/stage/raw/sources.yml
@@ -5,8 +5,32 @@ sources:
     schema: stage_raw
     tables:
       - name: name_basics
+        loaded_at_field: snapshot_date
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
       - name: title_principals
+        loaded_at_field: snapshot_date
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
       - name: title_basics
+        loaded_at_field: snapshot_date
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
       - name: title_ratings
+        loaded_at_field: snapshot_date
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
       - name: title_akas
+        loaded_at_field: snapshot_date
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
       - name: title_episode
+        loaded_at_field: snapshot_date
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}


### PR DESCRIPTION
## Summary
- Fixed duplicate column definitions in `person.yml`
- Changed FK test severity from `warn` to `error` across `title_episode.yml`, `fact_episode.yml`, `fact_title_release.yml`, `title_localized.yml`
- Added `not_null` tests to `snapshot_date`, `ingested_at_timestamp`, `snapshot_try` across all 11 canonical models
- Added `accepted_values` tests for `is_adult` and `title_type_name`
- Added `+partition_by: "snapshot_date"` to canonical and analytics configs in `dbt_project.yml`
- Added source freshness (warn 24h / error 48h) to all source tables
- Added column descriptions for audit columns across all ymls
- Added value examples to `dim_title.yml` for `decade` and `rating_bucket` (LLM readability)
- Added `is_alive` boolean column to `dim_person`

## Test plan
- [ ] Run `dbt test` and verify no warnings on FK tests (now errors)
- [ ] Verify `dbt source freshness` works with `snapshot_date`
- [ ] Verify `dim_person` query returns `is_alive` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)