### PR TITLE
improve(ai): eval scoring, LIMIT fix, query timeout, prompt anti-patterns

### DIFF
--- a/ai/eval/eval_script.py
+++ b/ai/eval/eval_script.py
@@ -3,6 +3,11 @@ import requests
 from pathlib import Path
 import json
 import time
+import logging
+from collections import defaultdict
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
 
 # API endpoint
 url = "http://localhost:8001/query"
@@ -14,6 +19,7 @@ version = 6
 # Paths
 questions_to_eval = Path("/usr/app/ai/eval/questions_analytics.yml")
 results_file = Path(f"/usr/app/ai/eval/{model}_v{version}_results.txt")
+summary_file = Path(f"/usr/app/ai/eval/{model}_v{version}_summary.json")
 
 # Load YAML
 with open(questions_to_eval, "r", encoding="utf-8") as f:
@@ -26,9 +32,10 @@ all_results = []
 
 for q in questions:
     question_id = q.get("id")
-    print(f"Evaluating question ID: {question_id}")
+    logger.info(f"Evaluating question ID: {question_id}")
     question_text = q.get("natural_language")
     question_sql_expected = q.get("sql_expected")
+    question_difficulty = q.get("difficulty")
     if not question_text:
         continue
 
@@ -46,17 +53,19 @@ for q in questions:
         # Build record
         record = {
             "id": question_id,
+            "difficulty": question_difficulty,
             "question": question_text,
             "sql_generated": result.get("sql"),
             "error": result.get("error"),
             "metrics": result.get("metrics"),
-            "sql_expected": question_sql_expected            
+            "sql_expected": question_sql_expected
         }
 
     except requests.RequestException as e:
-        print(f"Failed to query '{question_text}': {e}")
+        logger.error(f"Failed to query '{question_text}': {e}")
         record = {
             "id": question_id,
+            "difficulty": question_difficulty,
             "question": question_text,
             "error": str(e)
         }
@@ -70,4 +79,73 @@ for q in questions:
 with open(results_file, "w", encoding="utf-8") as f_out:
     json.dump(all_results, f_out, indent=2)
 
-print(f"Saved {len(all_results)} results to {results_file}")
+logger.info(f"Saved {len(all_results)} results to {results_file}")
+
+# -------------------------------------------------------
+# Scoring
+# -------------------------------------------------------
+
+def is_pass(record: dict) -> bool:
+    """A result passes if it has a non-empty sql and no error field."""
+    sql = record.get("sql_generated") or ""
+    error = record.get("error")
+    return bool(sql.strip()) and not error
+
+total = len(all_results)
+pass_count = sum(1 for r in all_results if is_pass(r))
+fail_count = total - pass_count
+pass_rate = round(pass_count / total * 100, 1) if total > 0 else 0.0
+
+# Breakdown by difficulty
+difficulty_stats: dict = defaultdict(lambda: {"total": 0, "pass": 0, "fail": 0})
+for r in all_results:
+    diff = r.get("difficulty") or "unknown"
+    difficulty_stats[diff]["total"] += 1
+    if is_pass(r):
+        difficulty_stats[diff]["pass"] += 1
+    else:
+        difficulty_stats[diff]["fail"] += 1
+
+# Error count by type
+error_counts: dict = defaultdict(int)
+for r in all_results:
+    if not is_pass(r):
+        err = r.get("error") or "no_sql_generated"
+        # Classify by first meaningful token
+        key = err.split(":")[0].strip() if err else "unknown"
+        error_counts[key] += 1
+
+# Build summary
+summary = {
+    "model": model,
+    "version": version,
+    "total": total,
+    "pass": pass_count,
+    "fail": fail_count,
+    "pass_rate_pct": pass_rate,
+    "by_difficulty": {k: dict(v) for k, v in difficulty_stats.items()},
+    "error_counts": dict(error_counts),
+}
+
+# Persist summary
+with open(summary_file, "w", encoding="utf-8") as f_sum:
+    json.dump(summary, f_sum, indent=2)
+
+# Print human-readable summary
+logger.info("=" * 50)
+logger.info("EVAL SUMMARY")
+logger.info("=" * 50)
+logger.info(f"Total questions : {total}")
+logger.info(f"Pass            : {pass_count}")
+logger.info(f"Fail            : {fail_count}")
+logger.info(f"Pass rate       : {pass_rate}%")
+if difficulty_stats:
+    logger.info("--- By difficulty ---")
+    for diff, stats in sorted(difficulty_stats.items()):
+        diff_rate = round(stats["pass"] / stats["total"] * 100, 1) if stats["total"] > 0 else 0.0
+        logger.info(f"  {diff:12s}: {stats['pass']}/{stats['total']} ({diff_rate}%)")
+if error_counts:
+    logger.info("--- Error breakdown ---")
+    for err_type, count in sorted(error_counts.items(), key=lambda x: -x[1]):
+        logger.info(f"  {err_type}: {count}")
+logger.info(f"Summary saved to {summary_file}")

--- a/ai/eval/version_control/qwen2.5-coder/eval_config_v6.yml
+++ b/ai/eval/version_control/qwen2.5-coder/eval_config_v6.yml
@@ -180,17 +180,16 @@ eval_config:
       ORDER BY t.average_rating DESC
       LIMIT 20;
 
-      EXAMPLE 6 (cross-fact: cast + genre — genre_name comes from fact_title_genre_flat, not fact_title_cast_crew):
+      EXAMPLE 6 (cross-fact: cast + genre — genre_name and title_type_name come from fact_title_genre_flat, no dim_title join needed just for title_type_name):
       Question:
       For each genre, how many distinct directors have worked on movies in that genre?
 
       SQL:
       SELECT g.genre_name, COUNT(DISTINCT c.person_id) AS director_count
       FROM demo.stage_analytics.fact_title_cast_crew c
-      JOIN demo.stage_analytics.dim_title t ON c.title_id = t.title_id
       JOIN demo.stage_analytics.fact_title_genre_flat g ON c.title_id = g.title_id
       WHERE c.role_name = 'director'
-        AND t.title_type_name = 'movie'
+        AND g.title_type_name = 'movie'
       GROUP BY g.genre_name
       ORDER BY director_count DESC;
 
@@ -215,6 +214,11 @@ eval_config:
         HAVING COUNT(DISTINCT f.title_id) >= 3
       ) ranked
       WHERE rn <= 3;
+
+      ANTI-PATTERNS (do NOT do this):
+      - Do NOT join dim_title just to filter title_type_name when using fact_title_genre_flat — that column is already in the fact table
+      - Do NOT select primary_title from fact_title_cast_crew — join dim_title instead
+      - Do NOT use fact_title_genre (array-based) when fact_title_genre_flat is available
 
       TASK:
       Generate a single Spark SQL SELECT query that answers the following question:

--- a/ai/text-to-sql/app/compiler/capabilities.py
+++ b/ai/text-to-sql/app/compiler/capabilities.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import glob
+import os
+import threading
 from ollama import Client
 import jaydebeapi
 from typing import List, Dict, Any, Mapping
@@ -13,6 +15,7 @@ SPARK_THRIFT_HOST = "spark-thrift-server"
 SPARK_THRIFT_PORT = 10000
 DATABASE = "demo.stage_analytics"
 SPARK_JARS = ":".join(glob.glob("/opt/bitnami/spark/jars/*.jar"))
+QUERY_TIMEOUT_SEC = int(os.getenv("QUERY_TIMEOUT_SEC", "30"))
 
 # load schemas once
 DATA_FOLDER = Path(__file__).parent.parent.parent / "data"
@@ -71,11 +74,32 @@ def generate_sql(user_query: str, prompt_config: Any, history: List[Dict[str, st
 
 
 def execute_sql_query(sql: str) -> Dict[str, Any]:
-    cursor = SPARK_CLIENT.cursor()
-    cursor.execute(sql)
-    columns = [desc[0] for desc in cursor.description]
-    rows = cursor.fetchall()
-    cursor.close()
-    return {"columns": columns, "rows": rows}
+    result_container: Dict[str, Any] = {}
+    exception_container: Dict[str, Exception] = {}
+
+    def _run() -> None:
+        try:
+            cursor = SPARK_CLIENT.cursor()
+            cursor.execute(sql)
+            columns = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchall()
+            cursor.close()
+            result_container["result"] = {"columns": columns, "rows": rows}
+        except Exception as exc:  # noqa: BLE001
+            exception_container["exc"] = exc
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    thread.join(timeout=QUERY_TIMEOUT_SEC)
+
+    if thread.is_alive():
+        raise TimeoutError(
+            f"Query execution exceeded the {QUERY_TIMEOUT_SEC}s timeout limit"
+        )
+
+    if "exc" in exception_container:
+        raise exception_container["exc"]
+
+    return result_container["result"]
 
 

--- a/ai/text-to-sql/app/compiler/nodes.py
+++ b/ai/text-to-sql/app/compiler/nodes.py
@@ -31,27 +31,49 @@ def repair_sql_node(state: RunnerState) -> dict:
         "error": None,
     }
 
+_AGGREGATION_KEYWORDS = re.compile(
+    r"\b(COUNT|SUM|AVG|MAX|MIN)\s*\(", re.IGNORECASE
+)
+
+def _needs_limit(sql: str) -> bool:
+    """Return True only when it is safe to inject LIMIT 10.
+
+    LIMIT is NOT injected when the query already has a LIMIT, uses GROUP BY,
+    uses HAVING, or contains aggregation functions (COUNT/SUM/AVG/MAX/MIN).
+    """
+    upper = sql.upper()
+    if "LIMIT" in upper:
+        return False
+    if "GROUP BY" in upper:
+        return False
+    if "HAVING" in upper:
+        return False
+    if _AGGREGATION_KEYWORDS.search(sql):
+        return False
+    return True
+
+
 def sanitize_sql_node(state: RunnerState) -> dict:
     """
     Strip ```sql``` blocks, leading/trailing whitespace, etc.
-    Add 'LIMIT 10' if no LIMIT is present in the query.
+    Add 'LIMIT 10' only if the query has no LIMIT, no GROUP BY, no HAVING,
+    and no aggregation functions (COUNT, SUM, AVG, MAX, MIN).
     """
     sql = state["llm_response"]["message"]["content"].strip()
-    
+
     # Remove ```sql ... ``` fences
     if sql.startswith("```sql"):
         sql = "\n".join(sql.splitlines()[1:-1])
-    
+
     sql = sql.strip()
-    
-    # Check if LIMIT exists anywhere (case-insensitive)
-    if "LIMIT" not in sql.upper():
+
+    if _needs_limit(sql):
         # Preserve existing semicolon if present
         ends_with_semicolon = sql.strip().endswith(";")
         sql = sql.rstrip("; \t\n") + " LIMIT 10"
         if ends_with_semicolon:
             sql += ";"
-    
+
     return {"sql_sanitised": sql}
 
 FORBIDDEN_KEYWORDS = [
@@ -102,10 +124,13 @@ def validate_sql_node(state):
         return state
 
     # -------------------------
-    # Rule 4: enforce LIMIT
+    # Rule 4: enforce LIMIT (exempt aggregation / grouped queries)
     # -------------------------
 
-    if "limit" not in query:
+    has_group_by = "group by" in query
+    has_having = "having" in query
+    has_aggregation = bool(_AGGREGATION_KEYWORDS.search(query))
+    if "limit" not in query and not (has_group_by or has_having or has_aggregation):
         state["error"] = "Query must include a LIMIT clause"
         return state
 

--- a/ai/text-to-sql/app/routes.py
+++ b/ai/text-to-sql/app/routes.py
@@ -1,7 +1,10 @@
+import logging
 from fastapi import APIRouter
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Any, Optional
 from .compiler.runner import SQLAgent
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 runner = SQLAgent()
@@ -17,17 +20,22 @@ class QueryResponse(BaseModel):
     metrics: dict
 
 class QueryRequest(BaseModel):
-    question: str
+    question: str = Field(..., min_length=5, max_length=500)
     model: str
-    version: int
+    version: int = Field(..., ge=1, le=10)
 
 @router.post("/query", response_model=QueryResponse)
 def query(request: QueryRequest):
-    print(f"Received query: {request.question} for model: {request.model} version: {request.version}")
+    logger.info(
+        "Received query: %s for model: %s version: %s",
+        request.question,
+        request.model,
+        request.version,
+    )
     result = runner.run(request.question, model=request.model, version=request.version)
     return QueryResponse(
         sql=result.get("sql"),
         result=result.get("result"),
         error=result.get("error"),
-        metrics=result.get("metrics")
-        )
+        metrics=result.get("metrics"),
+    )


### PR DESCRIPTION
## Summary
- Added automated scoring to `eval_script.py`: total/pass/fail/pass-rate, per-difficulty breakdown, error count by type; saves `*_summary.json`
- Fixed LIMIT injection in `nodes.py`: no longer adds `LIMIT 10` to queries with `GROUP BY`, `HAVING`, or aggregation functions
- Added configurable query execution timeout (`QUERY_TIMEOUT_SEC`, default 30s) with threading-based enforcement
- Fixed conflicting prompt example (Example 6): removed redundant `dim_title` JOIN when `fact_title_genre_flat` already has `title_type_name`
- Added Pydantic `Field` constraints to `QueryRequest` (`question` min/max length, `version` range)
- Replaced `print()` with structured `logging` in routes.py and eval_script.py
- Added `ANTI-PATTERNS` section to `eval_config_v6.yml` documenting 3 common LLM mistakes

## Test plan
- [ ] Run eval script and verify summary JSON is generated with pass/fail counts
- [ ] Test a GROUP BY query and verify LIMIT is not injected
- [ ] Verify a slow query raises TimeoutError after 30s
- [ ] Verify invalid `question` (too short) returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)